### PR TITLE
Add post-app-clone Trigger

### DIFF
--- a/post-app-clone
+++ b/post-app-clone
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/global-cert/internal-functions"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+hook-post-app-clone-global-cert() {
+  declare desc="sets global certs for an app"
+  local APP="$2"
+  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  local CRT_FILE="$PLUGIN_CONFIG_ROOT/server.crt"
+  local KEY_FILE="$PLUGIN_CONFIG_ROOT/server.key"
+
+  if fn-is-ssl-enabled "$PLUGIN_CONFIG_ROOT"; then
+    # we should export certs_set as a function in the certs plugin so that this works with the remote cli...
+    dokku certs:add "$APP" "$CRT_FILE" "$KEY_FILE"
+  fi
+}
+
+hook-post-app-clone-global-cert "$@"


### PR DESCRIPTION
I was working with the [Dokku/Gitlab-CI](https://github.com/dokku/gitlab-ci) examples and had issues with review apps and my global-cert. 

Issue:
Review apps use `dokku apps:clone`, but that command won't clone certificates and won't trigger `post-create`.

Fix:
After adding a `post-app-clone` trigger, my review apps were getting the correct certificate after being cloned.